### PR TITLE
Add Registry API support for entity, device, area, label, and floor metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,106 @@ hago lovelace remove-dashboard my-dash
 hago lovelace resources
 ```
 
+## Registry API
+
+The library provides access to Home Assistant's registry APIs for querying metadata about entities, devices, areas, labels, and floors. This metadata isn't available through the state API and is essential for organization and understanding entity relationships.
+
+### Library Usage
+
+```go
+// Entity Registry - list all entities with metadata
+entities, err := client.EntityRegistry(ctx)
+for _, entity := range entities {
+    fmt.Printf("%s: area=%s, labels=%v\n",
+        entity.EntityID,
+        *entity.AreaID,
+        entity.Labels)
+}
+
+// Device Registry - list all devices
+devices, err := client.DeviceRegistry(ctx)
+for _, device := range devices {
+    fmt.Printf("%s: %s %s (sw: %s)\n",
+        device.Name,
+        *device.Manufacturer,
+        *device.Model,
+        *device.SWVersion)
+}
+
+// Area Registry - list all areas/rooms
+areas, err := client.AreaRegistry(ctx)
+
+// Label Registry - list user-defined labels
+labels, err := client.LabelRegistry(ctx)
+
+// Floor Registry - list building levels
+floors, err := client.FloorRegistry(ctx)
+```
+
+### CLI Usage
+
+```bash
+# List entity registry entries (with area, device, label assignments)
+hago registry entities
+
+# List device registry entries (with hardware info)
+hago registry devices
+
+# List area registry entries (rooms/locations)
+hago registry areas
+
+# List label registry entries (user-defined tags)
+hago registry labels
+
+# List floor registry entries (building levels)
+hago registry floors
+
+# Use with jq for filtering
+hago registry entities -o json | jq '.[] | select(.area_id=="living_room")'
+hago registry devices -o json | jq '.[] | select(.manufacturer=="Philips")'
+```
+
+### Registry Types
+
+**Entity Registry** provides:
+- Area assignments
+- Device associations
+- Labels and categories
+- Custom icons and names
+- Disabled/hidden status
+- Platform information
+
+**Device Registry** provides:
+- Manufacturer, model, hardware version
+- Firmware/software versions
+- Serial numbers
+- Area assignments
+- Device connections and identifiers
+- Configuration URLs
+
+**Area Registry** provides:
+- Room/location names
+- Floor assignments
+- Icons and pictures
+- Aliases (alternative names)
+- Labels
+
+**Label Registry** provides:
+- User-defined organizational tags
+- Icons and colors
+- Descriptions
+
+**Floor Registry** provides:
+- Building level names
+- Level numbers (for ordering)
+- Icons
+- Aliases
+
 ## Features
 
 - Full Home Assistant REST API coverage
 - WebSocket API for Lovelace dashboard management
+- Registry API for entity/device/area/label/floor metadata
 - Functional options pattern for configuration
 - Context support for cancellation and timeouts
 - Strongly typed requests and responses
@@ -279,6 +375,12 @@ hago lovelace resources
 - [x] Template rendering (`/api/template`)
 - [x] Configuration check (`/api/config/core/check_config`)
 - [x] Intent handling (`/api/intent/handle`)
+- [x] Registry APIs (`/api/config/*_registry/list`)
+  - Entity Registry
+  - Device Registry
+  - Area Registry
+  - Label Registry
+  - Floor Registry
 
 ### WebSocket API
 - [x] Lovelace dashboard list (`lovelace/dashboards/list`)

--- a/cmd/hago/cmd/registry.go
+++ b/cmd/hago/cmd/registry.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var registryCmd = &cobra.Command{
+	Use:   "registry",
+	Short: "Query Home Assistant registries",
+	Long: `Query Home Assistant registry APIs for metadata about entities, devices, areas, labels, and floors.
+
+Registries store organizational metadata that isn't available through the state API,
+such as area assignments, device information, and user-defined labels.`,
+}
+
+var entityRegistryCmd = &cobra.Command{
+	Use:     "entities",
+	Aliases: []string{"entity", "ent"},
+	Short:   "List entity registry entries",
+	Long: `List all entities in the registry with metadata including:
+- Area assignments
+- Device associations
+- Labels and categories
+- Custom icons and names
+- Disabled/hidden status`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		entries, err := getClient().EntityRegistry(ctx)
+		if err != nil {
+			return err
+		}
+		return printResult(entries)
+	},
+}
+
+var deviceRegistryCmd = &cobra.Command{
+	Use:     "devices",
+	Aliases: []string{"device", "dev"},
+	Short:   "List device registry entries",
+	Long: `List all devices in the registry with metadata including:
+- Manufacturer, model, and hardware details
+- Firmware/software versions
+- Area assignments
+- Device connections and identifiers
+- Labels`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		entries, err := getClient().DeviceRegistry(ctx)
+		if err != nil {
+			return err
+		}
+		return printResult(entries)
+	},
+}
+
+var areaRegistryCmd = &cobra.Command{
+	Use:     "areas",
+	Aliases: []string{"area"},
+	Short:   "List area registry entries",
+	Long: `List all areas (rooms/locations) in the registry with metadata including:
+- Floor assignments
+- Icons and pictures
+- Aliases
+- Labels`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		entries, err := getClient().AreaRegistry(ctx)
+		if err != nil {
+			return err
+		}
+		return printResult(entries)
+	},
+}
+
+var labelRegistryCmd = &cobra.Command{
+	Use:     "labels",
+	Aliases: []string{"label"},
+	Short:   "List label registry entries",
+	Long: `List all labels (user-defined organizational tags) in the registry with metadata including:
+- Icons and colors
+- Descriptions`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		entries, err := getClient().LabelRegistry(ctx)
+		if err != nil {
+			return err
+		}
+		return printResult(entries)
+	},
+}
+
+var floorRegistryCmd = &cobra.Command{
+	Use:     "floors",
+	Aliases: []string{"floor"},
+	Short:   "List floor registry entries",
+	Long: `List all floors (building levels) in the registry with metadata including:
+- Level numbers
+- Icons
+- Aliases`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		entries, err := getClient().FloorRegistry(ctx)
+		if err != nil {
+			return err
+		}
+		return printResult(entries)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(registryCmd)
+
+	registryCmd.AddCommand(entityRegistryCmd)
+	registryCmd.AddCommand(deviceRegistryCmd)
+	registryCmd.AddCommand(areaRegistryCmd)
+	registryCmd.AddCommand(labelRegistryCmd)
+	registryCmd.AddCommand(floorRegistryCmd)
+}

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,119 @@
+package hago
+
+import (
+	"context"
+	"fmt"
+)
+
+// EntityRegistryEntry represents an entity in the registry.
+type EntityRegistryEntry struct {
+	EntityID      string            `json:"entity_id"`
+	Name          *string           `json:"name"`
+	AreaID        *string           `json:"area_id"`
+	DeviceID      *string           `json:"device_id"`
+	Labels        []string          `json:"labels"`
+	Icon          *string           `json:"icon"`
+	DisabledBy    *string           `json:"disabled_by"`
+	HiddenBy      *string           `json:"hidden_by"`
+	HasEntityName bool              `json:"has_entity_name"`
+	Platform      string            `json:"platform"`
+	Categories    map[string]string `json:"categories,omitempty"`
+	OriginalIcon  *string           `json:"original_icon,omitempty"`
+	OriginalName  *string           `json:"original_name,omitempty"`
+	UniqueID      string            `json:"unique_id"`
+}
+
+// DeviceRegistryEntry represents a device in the registry.
+type DeviceRegistryEntry struct {
+	ID               string     `json:"id"`
+	Name             string     `json:"name"`
+	AreaID           *string    `json:"area_id"`
+	ConfigEntries    []string   `json:"config_entries"`
+	Connections      [][]string `json:"connections"`
+	DisabledBy       *string    `json:"disabled_by"`
+	Identifiers      [][]string `json:"identifiers"`
+	Manufacturer     *string    `json:"manufacturer"`
+	Model            *string    `json:"model"`
+	NameByUser       *string    `json:"name_by_user"`
+	SWVersion        *string    `json:"sw_version"`
+	HWVersion        *string    `json:"hw_version"`
+	SerialNumber     *string    `json:"serial_number"`
+	ViaDeviceID      *string    `json:"via_device_id"`
+	ConfigurationURL *string    `json:"configuration_url"`
+	EntryType        *string    `json:"entry_type"`
+	Labels           []string   `json:"labels"`
+}
+
+// AreaRegistryEntry represents an area in the registry.
+type AreaRegistryEntry struct {
+	AreaID  string   `json:"area_id"`
+	Name    string   `json:"name"`
+	FloorID *string  `json:"floor_id"`
+	Icon    *string  `json:"icon"`
+	Picture *string  `json:"picture"`
+	Aliases []string `json:"aliases"`
+	Labels  []string `json:"labels"`
+}
+
+// LabelRegistryEntry represents a label in the registry.
+type LabelRegistryEntry struct {
+	LabelID     string  `json:"label_id"`
+	Name        string  `json:"name"`
+	Icon        *string `json:"icon"`
+	Color       *string `json:"color"`
+	Description *string `json:"description"`
+}
+
+// FloorRegistryEntry represents a floor in the registry.
+type FloorRegistryEntry struct {
+	FloorID string   `json:"floor_id"`
+	Name    string   `json:"name"`
+	Icon    *string  `json:"icon"`
+	Level   *int     `json:"level"`
+	Aliases []string `json:"aliases"`
+}
+
+// EntityRegistry lists all entities in the registry with metadata.
+func (c *Client) EntityRegistry(ctx context.Context) ([]EntityRegistryEntry, error) {
+	var entries []EntityRegistryEntry
+	if err := c.doJSON(ctx, "GET", "/api/config/entity_registry/list", nil, &entries); err != nil {
+		return nil, fmt.Errorf("entity registry: %w", err)
+	}
+	return entries, nil
+}
+
+// DeviceRegistry lists all devices in the registry.
+func (c *Client) DeviceRegistry(ctx context.Context) ([]DeviceRegistryEntry, error) {
+	var entries []DeviceRegistryEntry
+	if err := c.doJSON(ctx, "GET", "/api/config/device_registry/list", nil, &entries); err != nil {
+		return nil, fmt.Errorf("device registry: %w", err)
+	}
+	return entries, nil
+}
+
+// AreaRegistry lists all areas in the registry.
+func (c *Client) AreaRegistry(ctx context.Context) ([]AreaRegistryEntry, error) {
+	var entries []AreaRegistryEntry
+	if err := c.doJSON(ctx, "GET", "/api/config/area_registry/list", nil, &entries); err != nil {
+		return nil, fmt.Errorf("area registry: %w", err)
+	}
+	return entries, nil
+}
+
+// LabelRegistry lists all labels in the registry.
+func (c *Client) LabelRegistry(ctx context.Context) ([]LabelRegistryEntry, error) {
+	var entries []LabelRegistryEntry
+	if err := c.doJSON(ctx, "GET", "/api/config/label_registry/list", nil, &entries); err != nil {
+		return nil, fmt.Errorf("label registry: %w", err)
+	}
+	return entries, nil
+}
+
+// FloorRegistry lists all floors in the registry.
+func (c *Client) FloorRegistry(ctx context.Context) ([]FloorRegistryEntry, error) {
+	var entries []FloorRegistryEntry
+	if err := c.doJSON(ctx, "GET", "/api/config/floor_registry/list", nil, &entries); err != nil {
+		return nil, fmt.Errorf("floor registry: %w", err)
+	}
+	return entries, nil
+}

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,280 @@
+package hago
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient_EntityRegistry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/entity_registry/list" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Error("missing or invalid authorization header")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[
+			{
+				"entity_id": "light.living_room",
+				"name": "Living Room Light",
+				"area_id": "living_room",
+				"device_id": "device123",
+				"labels": ["smart", "lighting"],
+				"icon": "mdi:lightbulb",
+				"disabled_by": null,
+				"hidden_by": null,
+				"has_entity_name": true,
+				"platform": "hue",
+				"unique_id": "hue-001"
+			},
+			{
+				"entity_id": "sensor.temperature",
+				"name": null,
+				"area_id": null,
+				"device_id": "device456",
+				"labels": [],
+				"icon": null,
+				"disabled_by": null,
+				"hidden_by": null,
+				"has_entity_name": false,
+				"platform": "mqtt",
+				"unique_id": "mqtt-temp-001"
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	client, _ := New(WithBaseURL(server.URL), WithToken("test-token"))
+	ctx := context.Background()
+
+	entries, err := client.EntityRegistry(ctx)
+	if err != nil {
+		t.Fatalf("EntityRegistry() error = %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+
+	if entries[0].EntityID != "light.living_room" {
+		t.Errorf("expected entity_id light.living_room, got %s", entries[0].EntityID)
+	}
+	if entries[0].Name == nil || *entries[0].Name != "Living Room Light" {
+		t.Error("expected name to be 'Living Room Light'")
+	}
+	if entries[0].AreaID == nil || *entries[0].AreaID != "living_room" {
+		t.Error("expected area_id to be 'living_room'")
+	}
+	if len(entries[0].Labels) != 2 {
+		t.Errorf("expected 2 labels, got %d", len(entries[0].Labels))
+	}
+}
+
+func TestClient_DeviceRegistry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/device_registry/list" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[
+			{
+				"id": "device123",
+				"name": "Philips Hue Bridge",
+				"area_id": "office",
+				"config_entries": ["config1"],
+				"connections": [["mac", "00:11:22:33:44:55"]],
+				"disabled_by": null,
+				"identifiers": [["hue", "bridge001"]],
+				"manufacturer": "Philips",
+				"model": "BSB002",
+				"name_by_user": "Hue Bridge Office",
+				"sw_version": "1.2.3",
+				"hw_version": "2.1",
+				"serial_number": "ABC123",
+				"via_device_id": null,
+				"configuration_url": "http://192.168.1.100",
+				"entry_type": "service",
+				"labels": ["bridge"]
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	client, _ := New(WithBaseURL(server.URL), WithToken("test-token"))
+	ctx := context.Background()
+
+	entries, err := client.DeviceRegistry(ctx)
+	if err != nil {
+		t.Fatalf("DeviceRegistry() error = %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(entries))
+	}
+
+	if entries[0].ID != "device123" {
+		t.Errorf("expected id device123, got %s", entries[0].ID)
+	}
+	if entries[0].Manufacturer == nil || *entries[0].Manufacturer != "Philips" {
+		t.Error("expected manufacturer to be 'Philips'")
+	}
+	if entries[0].Model == nil || *entries[0].Model != "BSB002" {
+		t.Error("expected model to be 'BSB002'")
+	}
+}
+
+func TestClient_AreaRegistry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/area_registry/list" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[
+			{
+				"area_id": "living_room",
+				"name": "Living Room",
+				"floor_id": "ground_floor",
+				"icon": "mdi:sofa",
+				"picture": "/local/living_room.jpg",
+				"aliases": ["lounge", "family room"],
+				"labels": ["main"]
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	client, _ := New(WithBaseURL(server.URL), WithToken("test-token"))
+	ctx := context.Background()
+
+	entries, err := client.AreaRegistry(ctx)
+	if err != nil {
+		t.Fatalf("AreaRegistry() error = %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(entries))
+	}
+
+	if entries[0].AreaID != "living_room" {
+		t.Errorf("expected area_id living_room, got %s", entries[0].AreaID)
+	}
+	if entries[0].Name != "Living Room" {
+		t.Errorf("expected name 'Living Room', got %s", entries[0].Name)
+	}
+	if len(entries[0].Aliases) != 2 {
+		t.Errorf("expected 2 aliases, got %d", len(entries[0].Aliases))
+	}
+}
+
+func TestClient_LabelRegistry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/label_registry/list" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[
+			{
+				"label_id": "security",
+				"name": "Security",
+				"icon": "mdi:shield",
+				"color": "#FF0000",
+				"description": "Security-related devices"
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	client, _ := New(WithBaseURL(server.URL), WithToken("test-token"))
+	ctx := context.Background()
+
+	entries, err := client.LabelRegistry(ctx)
+	if err != nil {
+		t.Fatalf("LabelRegistry() error = %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(entries))
+	}
+
+	if entries[0].LabelID != "security" {
+		t.Errorf("expected label_id security, got %s", entries[0].LabelID)
+	}
+	if entries[0].Name != "Security" {
+		t.Errorf("expected name 'Security', got %s", entries[0].Name)
+	}
+	if entries[0].Color == nil || *entries[0].Color != "#FF0000" {
+		t.Error("expected color to be '#FF0000'")
+	}
+}
+
+func TestClient_FloorRegistry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/floor_registry/list" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[
+			{
+				"floor_id": "ground_floor",
+				"name": "Ground Floor",
+				"icon": "mdi:home",
+				"level": 0,
+				"aliases": ["first floor", "main floor"]
+			},
+			{
+				"floor_id": "upstairs",
+				"name": "Upstairs",
+				"icon": "mdi:stairs-up",
+				"level": 1,
+				"aliases": ["second floor"]
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	client, _ := New(WithBaseURL(server.URL), WithToken("test-token"))
+	ctx := context.Background()
+
+	entries, err := client.FloorRegistry(ctx)
+	if err != nil {
+		t.Fatalf("FloorRegistry() error = %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+
+	if entries[0].FloorID != "ground_floor" {
+		t.Errorf("expected floor_id ground_floor, got %s", entries[0].FloorID)
+	}
+	if entries[0].Level == nil || *entries[0].Level != 0 {
+		t.Error("expected level to be 0")
+	}
+	if len(entries[0].Aliases) != 2 {
+		t.Errorf("expected 2 aliases, got %d", len(entries[0].Aliases))
+	}
+}
+
+func TestClient_EntityRegistry_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message": "Unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client, _ := New(WithBaseURL(server.URL), WithToken("bad-token"))
+	ctx := context.Background()
+
+	_, err := client.EntityRegistry(ctx)
+	if err == nil {
+		t.Fatal("expected error for unauthorized request")
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds support for Home Assistant's Registry REST APIs, enabling querying of metadata about entities, devices, areas, labels, and floors. This metadata is essential for organization and understanding entity relationships.

## Changes
- **Registry Types** (`registry.go`)
  - `EntityRegistryEntry` - entity metadata with area, device, labels, icons, disabled state
  - `DeviceRegistryEntry` - device information with manufacturer, model, firmware, connections
  - `AreaRegistryEntry` - rooms/locations with floor assignments, icons, aliases
  - `LabelRegistryEntry` - user-defined organizational tags with colors
  - `FloorRegistryEntry` - building levels with ordering and aliases

- **Registry Methods** (`registry.go`)
  - `EntityRegistry(ctx)` - List all entities with metadata
  - `DeviceRegistry(ctx)` - List all devices with hardware details
  - `AreaRegistry(ctx)` - List all areas/rooms
  - `LabelRegistry(ctx)` - List all labels/tags
  - `FloorRegistry(ctx)` - List all floors/levels

- **CLI Commands** (`cmd/hago/cmd/registry.go`)
  - `hago registry entities` - List entity registry entries
  - `hago registry devices` - List device registry entries
  - `hago registry areas` - List area registry entries
  - `hago registry labels` - List label registry entries
  - `hago registry floors` - List floor registry entries
  - All commands support JSON/pretty output and work with jq for filtering

- **Testing** (`registry_test.go`)
  - Tests for all registry methods with mock HTTP server
  - Tests for authorization errors
  - Tests verify proper endpoint paths and response parsing

## Features
- Read-only REST API operations (simpler than WebSocket)
- Comprehensive metadata access for organization and filtering
- Entity → Device → Area → Floor relationship mapping
- Label-based filtering and categorization
- Hardware information for devices (manufacturer, model, firmware)

## Use Cases
- Query entities by area or label
- Get complete device information with hardware details
- Understand entity → device → area → floor hierarchy
- Enhance state data with registry metadata
- Organization and relationship mapping

## Documentation
- Added comprehensive Registry API section to README
- Library usage examples for all registry types
- CLI usage examples with jq filtering patterns
- Detailed descriptions of what each registry type provides

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)