### PR TITLE
Fix: Registry API to use WebSocket instead of non-existent REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ hago lovelace resources
 
 ## Registry API
 
-The library provides access to Home Assistant's registry APIs for querying metadata about entities, devices, areas, labels, and floors. This metadata isn't available through the state API and is essential for organization and understanding entity relationships.
+The library provides access to Home Assistant's registry APIs via WebSocket for querying metadata about entities, devices, areas, labels, and floors. This metadata isn't available through the state API and is essential for organization and understanding entity relationships.
 
 ### Library Usage
 
@@ -375,12 +375,6 @@ hago registry devices -o json | jq '.[] | select(.manufacturer=="Philips")'
 - [x] Template rendering (`/api/template`)
 - [x] Configuration check (`/api/config/core/check_config`)
 - [x] Intent handling (`/api/intent/handle`)
-- [x] Registry APIs (`/api/config/*_registry/list`)
-  - Entity Registry
-  - Device Registry
-  - Area Registry
-  - Label Registry
-  - Floor Registry
 
 ### WebSocket API
 - [x] Lovelace dashboard list (`lovelace/dashboards/list`)
@@ -391,6 +385,12 @@ hago registry devices -o json | jq '.[] | select(.manufacturer=="Philips")'
 - [x] Lovelace dashboard update (`lovelace/dashboards/update`)
 - [x] Lovelace dashboard delete (`lovelace/dashboards/delete`)
 - [x] Lovelace resources list (`lovelace/resources`)
+- [x] Registry APIs (`config/*_registry/list`)
+  - Entity Registry
+  - Device Registry
+  - Area Registry
+  - Label Registry
+  - Floor Registry
 
 ## Contributing
 

--- a/registry.go
+++ b/registry.go
@@ -75,8 +75,9 @@ type FloorRegistryEntry struct {
 
 // EntityRegistry lists all entities in the registry with metadata.
 func (c *Client) EntityRegistry(ctx context.Context) ([]EntityRegistryEntry, error) {
+	cmd := map[string]string{"type": "config/entity_registry/list"}
 	var entries []EntityRegistryEntry
-	if err := c.doJSON(ctx, "GET", "/api/config/entity_registry/list", nil, &entries); err != nil {
+	if err := c.wsCommand(ctx, cmd, &entries); err != nil {
 		return nil, fmt.Errorf("entity registry: %w", err)
 	}
 	return entries, nil
@@ -84,8 +85,9 @@ func (c *Client) EntityRegistry(ctx context.Context) ([]EntityRegistryEntry, err
 
 // DeviceRegistry lists all devices in the registry.
 func (c *Client) DeviceRegistry(ctx context.Context) ([]DeviceRegistryEntry, error) {
+	cmd := map[string]string{"type": "config/device_registry/list"}
 	var entries []DeviceRegistryEntry
-	if err := c.doJSON(ctx, "GET", "/api/config/device_registry/list", nil, &entries); err != nil {
+	if err := c.wsCommand(ctx, cmd, &entries); err != nil {
 		return nil, fmt.Errorf("device registry: %w", err)
 	}
 	return entries, nil
@@ -93,8 +95,9 @@ func (c *Client) DeviceRegistry(ctx context.Context) ([]DeviceRegistryEntry, err
 
 // AreaRegistry lists all areas in the registry.
 func (c *Client) AreaRegistry(ctx context.Context) ([]AreaRegistryEntry, error) {
+	cmd := map[string]string{"type": "config/area_registry/list"}
 	var entries []AreaRegistryEntry
-	if err := c.doJSON(ctx, "GET", "/api/config/area_registry/list", nil, &entries); err != nil {
+	if err := c.wsCommand(ctx, cmd, &entries); err != nil {
 		return nil, fmt.Errorf("area registry: %w", err)
 	}
 	return entries, nil
@@ -102,8 +105,9 @@ func (c *Client) AreaRegistry(ctx context.Context) ([]AreaRegistryEntry, error) 
 
 // LabelRegistry lists all labels in the registry.
 func (c *Client) LabelRegistry(ctx context.Context) ([]LabelRegistryEntry, error) {
+	cmd := map[string]string{"type": "config/label_registry/list"}
 	var entries []LabelRegistryEntry
-	if err := c.doJSON(ctx, "GET", "/api/config/label_registry/list", nil, &entries); err != nil {
+	if err := c.wsCommand(ctx, cmd, &entries); err != nil {
 		return nil, fmt.Errorf("label registry: %w", err)
 	}
 	return entries, nil
@@ -111,8 +115,9 @@ func (c *Client) LabelRegistry(ctx context.Context) ([]LabelRegistryEntry, error
 
 // FloorRegistry lists all floors in the registry.
 func (c *Client) FloorRegistry(ctx context.Context) ([]FloorRegistryEntry, error) {
+	cmd := map[string]string{"type": "config/floor_registry/list"}
 	var entries []FloorRegistryEntry
-	if err := c.doJSON(ctx, "GET", "/api/config/floor_registry/list", nil, &entries); err != nil {
+	if err := c.wsCommand(ctx, cmd, &entries); err != nil {
 		return nil, fmt.Errorf("floor registry: %w", err)
 	}
 	return entries, nil


### PR DESCRIPTION
## Problem

The Registry API implementation in v0.3.0 was incorrectly attempting to use REST endpoints (`/api/config/*_registry/list`) that **do not exist** in Home Assistant. These endpoints return 404 errors because registry data is only accessible via the WebSocket API.

## Root Cause

During initial implementation, the Registry API was incorrectly assumed to be available via REST, similar to other Home Assistant APIs. However, the [official documentation](https://developers.home-assistant.io/docs/api/websocket/) confirms that registry data is only exposed through WebSocket commands.

## Solution

Convert all registry methods from REST API to WebSocket API:

### Changes Made
- **registry.go**: Updated all methods to use `wsCommand()` with WebSocket command types:
  - `config/entity_registry/list`
  - `config/device_registry/list`  
  - `config/area_registry/list`
  - `config/label_registry/list`
  - `config/floor_registry/list`

- **registry_test.go**: Completely rewrote tests to use `mockWSServer` instead of `httptest.NewServer`:
  - Added WebSocket auth flow to all tests
  - Verified correct WebSocket command types
  - Maintained same test coverage and assertions

- **README.md**: Updated documentation:
  - Clarified Registry API uses WebSocket (not REST)
  - Moved Registry APIs from REST to WebSocket section in API Coverage

## Testing

All tests pass with mock WebSocket server:
```
=== RUN   TestClient_EntityRegistry
--- PASS: TestClient_EntityRegistry (0.00s)
=== RUN   TestClient_DeviceRegistry
--- PASS: TestClient_DeviceRegistry (0.00s)
=== RUN   TestClient_AreaRegistry
--- PASS: TestClient_AreaRegistry (0.00s)
=== RUN   TestClient_LabelRegistry
--- PASS: TestClient_LabelRegistry (0.00s)
=== RUN   TestClient_FloorRegistry
--- PASS: TestClient_FloorRegistry (0.00s)
=== RUN   TestClient_EntityRegistry_Error
--- PASS: TestClient_EntityRegistry_Error (0.00s)
PASS
```

## Impact

- ✅ No breaking changes to public API (method signatures unchanged)
- ✅ Registry methods now work correctly with Home Assistant
- ✅ Existing code using registry methods will work without modification
- ✅ Tests verify correct WebSocket communication

## Verification

Tested against Home Assistant 2025.11.3:
- ✅ EntityRegistry returns entities with metadata
- ✅ DeviceRegistry returns devices with hardware info
- ✅ AreaRegistry returns areas/rooms
- ✅ LabelRegistry returns labels
- ✅ FloorRegistry returns floors

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)